### PR TITLE
Make modded logs strippable

### DIFF
--- a/src/main/java/dev/tophatcat/spookybiomes/common/blocks/SpookyLogBlock.java
+++ b/src/main/java/dev/tophatcat/spookybiomes/common/blocks/SpookyLogBlock.java
@@ -1,0 +1,32 @@
+package dev.tophatcat.spookybiomes.common.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class SpookyLogBlock extends RotatedPillarBlock {
+    private final Supplier<? extends Block> strippedLogBlock;
+
+    public SpookyLogBlock(final Properties properties, final Supplier<? extends Block> strippedLogBlock) {
+        super(properties);
+        this.strippedLogBlock = strippedLogBlock;
+    }
+
+    @Nullable
+    @Override
+    public BlockState getToolModifiedState(final BlockState state, final Level world, final BlockPos pos, final Player player, final ItemStack stack, final ToolAction toolAction) {
+        if (stack.canPerformAction(toolAction) && ToolActions.AXE_STRIP.equals(toolAction)) {
+            return strippedLogBlock.get().defaultBlockState().setValue(AXIS, state.getValue(AXIS));
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/tophatcat/spookybiomes/init/SpookyBlocks.java
+++ b/src/main/java/dev/tophatcat/spookybiomes/init/SpookyBlocks.java
@@ -2,6 +2,7 @@ package dev.tophatcat.spookybiomes.init;
 
 import dev.tophatcat.spookybiomes.SpookyBiomes;
 import dev.tophatcat.spookybiomes.common.blocks.BloodiedGrass;
+import dev.tophatcat.spookybiomes.common.blocks.SpookyLogBlock;
 import dev.tophatcat.spookybiomes.common.generation.BloodiedTreeGrower;
 import dev.tophatcat.spookybiomes.common.generation.GhostlyTreeGrower;
 import dev.tophatcat.spookybiomes.common.generation.SeepingTreeGrower;
@@ -46,9 +47,9 @@ public class SpookyBlocks {
         "sorbus_log_stripped", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
             .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
 
-    public static final RegistryObject<RotatedPillarBlock> SORBUS_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
-        "sorbus_log", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
-            .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
+    public static final RegistryObject<SpookyLogBlock> SORBUS_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
+        "sorbus_log", () -> new SpookyLogBlock(Properties.of(Material.WOOD)
+            .strength(2.0F, 5.0F).sound(SoundType.WOOD), SORBUS_LOG_STRIPPED));
 
     public static final RegistryObject<LeavesBlock> SORBUS_LEAVES = registerBlockAndStandardItem(BLOCKS, ITEMS,
         "sorbus_leaves", () -> new LeavesBlock(Properties.of(Material.LEAVES)
@@ -91,9 +92,9 @@ public class SpookyBlocks {
         "ghostly_log_stripped", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
             .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
 
-    public static final RegistryObject<RotatedPillarBlock> GHOSTLY_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
-        "ghostly_log", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
-            .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
+    public static final RegistryObject<SpookyLogBlock> GHOSTLY_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
+        "ghostly_log", () -> new SpookyLogBlock(Properties.of(Material.WOOD)
+            .strength(2.0F, 5.0F).sound(SoundType.WOOD), GHOSTLY_LOG_STRIPPED));
 
     public static final RegistryObject<LeavesBlock> GHOSTLY_LEAVES = registerBlockAndStandardItem(BLOCKS, ITEMS,
         "ghostly_leaves", () -> new LeavesBlock(Properties.of(Material.LEAVES)
@@ -136,9 +137,9 @@ public class SpookyBlocks {
         "seeping_log_stripped", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
             .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
 
-    public static final RegistryObject<RotatedPillarBlock> SEEPING_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
-        "seeping_log", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
-            .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
+    public static final RegistryObject<SpookyLogBlock> SEEPING_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
+        "seeping_log", () -> new SpookyLogBlock(Properties.of(Material.WOOD)
+            .strength(2.0F, 5.0F).sound(SoundType.WOOD), SEEPING_LOG_STRIPPED));
 
     public static final RegistryObject<LeavesBlock> SEEPING_LEAVES = registerBlockAndStandardItem(BLOCKS, ITEMS,
         "seeping_leaves", () -> new LeavesBlock(Properties.of(Material.LEAVES)
@@ -181,9 +182,9 @@ public class SpookyBlocks {
         "bloodwood_log_stripped", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
             .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
 
-    public static final RegistryObject<RotatedPillarBlock> BLOODWOOD_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
-        "bloodwood_log", () -> new RotatedPillarBlock(Properties.of(Material.WOOD)
-            .strength(2.0F, 5.0F).sound(SoundType.WOOD)));
+    public static final RegistryObject<SpookyLogBlock> BLOODWOOD_LOG = registerBlockAndStandardItem(BLOCKS, ITEMS,
+        "bloodwood_log", () -> new SpookyLogBlock(Properties.of(Material.WOOD)
+            .strength(2.0F, 5.0F).sound(SoundType.WOOD), BLOODWOOD_LOG_STRIPPED));
 
     public static final RegistryObject<LeavesBlock> BLOODWOOD_LEAVES = registerBlockAndStandardItem(BLOCKS, ITEMS,
         "bloodwood_leaves", () -> new LeavesBlock(Properties.of(Material.LEAVES)


### PR DESCRIPTION
This PR makes the mod's logs strippable with axes (or any tool which is capable of the `ToolAction.AXE_STRIP` action).