### PR TITLE
1.18.2 MCForge version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 	modApi "com.terraformersmc:modmenu:${modmenu_version}"
 
 	//Kiri's Lib dependency
-	modImplementation "maven.modrinth:kirislib:${kiris_lib_version}"
+	modImplementation "curse.maven:kiris-lib-280547:${kiris_lib_version}"
 
 	//TerraBlender
 	modImplementation "com.github.glitchfiend:TerraBlender-fabric:${minecraft_version}-${terrablender_version}"
@@ -86,7 +86,7 @@ dependencies {
 
 loom {
     if (project.hasProperty('quilt_aws_enabled') && project.findProperty('quilt_aws_enabled').toBoolean()) {
-        accessWidenerPath = file("src/main/resources/${mod_id}.accessWidener")
+        accessWidenerPath = file("src/main/resources/${mod_id}.accesswidener")
         project.logger.debug('Quilt Access Widener are enabled for this project.')
     }
     runs {

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,6 +43,6 @@ org.gradle.parallel=true
 
 # Dependencies are managed at gradle/libs.versions.toml
 # Kiri's Lib version key/version found on projects Modrinth page when you pick the file/version you want.
-kiris_lib_version=4.0.0-1.19.2
+kiris_lib_version=4372756
 modmenu_version=4.1.2
 terrablender_version=2.0.1.136


### PR DESCRIPTION
Hóla, I have ported the 1.17.1 version of this mod to 1.18.2 MC Forge because I want to use it in some modpacks Im making (Belt and Road Initiative, Escapar a Tijuana, and others) I liked this mod because it is not as bloated as the others and has a few high quality ones.

It should be quite the same as the 1.17.1 version with some minor changes to the datapack due to version changes, though i still need to try to see if the biomes spawn in. The only thing I added was Español translation based on the in game es_mx translations. Please analyse the 1.18.2 branch on my fork and then upload to Curseforge so I can add to modpack. Thank you!